### PR TITLE
Add PreLoadedPlugin mixin for pre-initialized plugins

### DIFF
--- a/packages/sanity/sanity_client/lib/client.dart
+++ b/packages/sanity/sanity_client/lib/client.dart
@@ -64,11 +64,11 @@ final class SanityConfig {
     bool? useCdn,
     Perspective? perspective,
     bool? explainQuery,
-  })  : this.useCdn = useCdn ?? true,
-        this.apiVersion = apiVersion ?? defaultApiVersion,
-        this.perspective = perspective ?? Perspective.raw,
-        this.explainQuery = explainQuery ?? false {
-    assert(this.token.trim().isNotEmpty, '''
+  })  : useCdn = useCdn ?? true,
+        apiVersion = apiVersion ?? defaultApiVersion,
+        perspective = perspective ?? Perspective.raw,
+        explainQuery = explainQuery ?? false {
+    assert(token.trim().isNotEmpty, '''
 Invalid Token provided. 
 Setup an API token, with Viewer access, in the Sanity Management Console.
 Without a valid token you will not be able to fetch data from Sanity.''');

--- a/packages/sanity/sanity_client/test/url_builder_test.dart
+++ b/packages/sanity/sanity_client/test/url_builder_test.dart
@@ -4,10 +4,10 @@ import 'package:sanity_client/sanity_client.dart';
 import 'util.dart';
 
 void main() {
-  [
+  for (var ref in [
     'invalid-ref',
     'imgInvalid-invalid-400x300-jpg',
-  ].forEach((ref) {
+  ]) {
     test('Invalid image-reference ($ref) throws exception', () {
       expect(
         () {
@@ -16,7 +16,7 @@ void main() {
         throwsA(const TypeMatcher<InvalidReferenceException>()),
       );
     });
-  });
+  }
 
   test('Valid image-reference generates proper image-url', () {
     final url = getClient()
@@ -26,10 +26,10 @@ void main() {
     expect(url, contains('cdn.sanity.io/images/$project/$dataset/'));
   });
 
-  [
+  for (var ref in [
     'invalid-ref',
     'fileInvalid-invalid-jpg',
-  ].forEach((ref) {
+  ]) {
     test('Invalid file-reference ($ref) throws exception', () {
       expect(
         () {
@@ -38,7 +38,7 @@ void main() {
         throwsA(const TypeMatcher<AssertionError>()),
       );
     });
-  });
+  }
 
   test('Valid file-reference generates proper file-url', () {
     final url = getClient()

--- a/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
@@ -6,7 +6,7 @@ import 'package:vyuh_core/vyuh_core.dart';
 
 /// The default implementation for an Analytics Plugin.
 final class AnalyticsPlugin extends Plugin
-    with PreLoadedPlugin
+    with PreloadedPlugin
     implements AnalyticsProvider {
   /// The list of providers for the plugin.
   final List<AnalyticsProvider> providers;

--- a/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
@@ -5,7 +5,9 @@ import 'package:flutter/widgets.dart';
 import 'package:vyuh_core/vyuh_core.dart';
 
 /// The default implementation for an Analytics Plugin.
-final class AnalyticsPlugin extends Plugin implements AnalyticsProvider {
+final class AnalyticsPlugin extends Plugin
+    with PreLoadedPlugin
+    implements AnalyticsProvider {
   /// The list of providers for the plugin.
   final List<AnalyticsProvider> providers;
 

--- a/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/analytics/analytics_plugin.dart
@@ -21,7 +21,6 @@ final class AnalyticsPlugin extends Plugin
       : super(
           name: 'vyuh.plugin.analytics',
           title: 'Analytics Plugin',
-          pluginType: PluginType.analytics,
         );
 
   @override

--- a/packages/system/vyuh_core/lib/plugin/auth/auth_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/auth/auth_plugin.dart
@@ -14,7 +14,7 @@ abstract class AuthPlugin<TUser extends User> extends Plugin {
 
   /// Creates an instance of [AuthPlugin].
   AuthPlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.auth);
+      : super();
 
   /// The current user that is signed in.
   TUser get currentUser => throw UnimplementedError();

--- a/packages/system/vyuh_core/lib/plugin/content/content_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/content/content_plugin.dart
@@ -11,7 +11,7 @@ abstract class ContentPlugin extends Plugin {
     required this.provider,
     required super.name,
     required super.title,
-  }) : super(pluginType: PluginType.content);
+  }) : super();
 
   /// The type registry that maps types to their descriptors
   Map<Type, Map<String, TypeDescriptor>> get typeRegistry;

--- a/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
@@ -4,7 +4,7 @@ import 'package:vyuh_core/vyuh_core.dart';
 /// It is associated with the Dependency Injection (DI) Plugin type and
 /// includes methods for registering, unregistering, retrieving, and
 /// checking the existence of instances in the DI container.
-abstract class DIPlugin extends Plugin {
+abstract class DIPlugin extends Plugin with PreLoadedPlugin {
   /// The `DIPlugin` constructor accepts two required parameters: `name` and `title`.
   DIPlugin({required super.name, required super.title})
       : super(pluginType: PluginType.di);

--- a/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
@@ -4,10 +4,9 @@ import 'package:vyuh_core/vyuh_core.dart';
 /// It is associated with the Dependency Injection (DI) Plugin type and
 /// includes methods for registering, unregistering, retrieving, and
 /// checking the existence of instances in the DI container.
-abstract class DIPlugin extends Plugin with PreLoadedPlugin {
+abstract class DIPlugin extends Plugin with PreloadedPlugin {
   /// The `DIPlugin` constructor accepts two required parameters: `name` and `title`.
-  DIPlugin({required super.name, required super.title})
-      : super();
+  DIPlugin({required super.name, required super.title}) : super();
 
   /// Registers an instance of any Object type with the DI container.
   void register<T extends Object>(T instance, {String? name});

--- a/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/di/di_plugin.dart
@@ -7,7 +7,7 @@ import 'package:vyuh_core/vyuh_core.dart';
 abstract class DIPlugin extends Plugin with PreLoadedPlugin {
   /// The `DIPlugin` constructor accepts two required parameters: `name` and `title`.
   DIPlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.di);
+      : super();
 
   /// Registers an instance of any Object type with the DI container.
   void register<T extends Object>(T instance, {String? name});

--- a/packages/system/vyuh_core/lib/plugin/feature_flag.dart
+++ b/packages/system/vyuh_core/lib/plugin/feature_flag.dart
@@ -12,7 +12,7 @@ abstract class FeatureFlagPlugin<TSettings, TContext> extends Plugin {
     required this.settings,
     required super.name,
     required super.title,
-  }) : super(pluginType: PluginType.featureFlag);
+  }) : super();
 
   /// Returns the value of the feature flag as a boolean.
   Future<bool> getBool(String featureName, {bool defaultValue = false});

--- a/packages/system/vyuh_core/lib/plugin/logger/logger_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/logger/logger_plugin.dart
@@ -2,7 +2,7 @@ import 'package:vyuh_core/vyuh_core.dart';
 
 abstract class LoggerPlugin extends Plugin {
   LoggerPlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.logger);
+      : super();
 
   /// trace
   void t(dynamic message);

--- a/packages/system/vyuh_core/lib/plugin/navigation/navigation.dart
+++ b/packages/system/vyuh_core/lib/plugin/navigation/navigation.dart
@@ -13,7 +13,7 @@ abstract class NavigationPlugin extends Plugin {
   );
 
   NavigationPlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.navigation);
+      : super();
 
   void initRouter({
     String? initialLocation,

--- a/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
@@ -7,7 +7,7 @@ abstract class NetworkPlugin extends Plugin
     with PreLoadedPlugin
     implements Client {
   NetworkPlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.network);
+      : super();
 
   @override
   Future<Response> get(Uri url, {Map<String, String>? headers});

--- a/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 import 'package:http/http.dart';
 import 'package:vyuh_core/vyuh_core.dart';
 
-abstract class NetworkPlugin extends Plugin implements Client {
+abstract class NetworkPlugin extends Plugin
+    with PreLoadedPlugin
+    implements Client {
   NetworkPlugin({required super.name, required super.title})
       : super(pluginType: PluginType.network);
 

--- a/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/network/network_plugin.dart
@@ -4,10 +4,9 @@ import 'package:http/http.dart';
 import 'package:vyuh_core/vyuh_core.dart';
 
 abstract class NetworkPlugin extends Plugin
-    with PreLoadedPlugin
+    with PreloadedPlugin
     implements Client {
-  NetworkPlugin({required super.name, required super.title})
-      : super();
+  NetworkPlugin({required super.name, required super.title}) : super();
 
   @override
   Future<Response> get(Uri url, {Map<String, String>? headers});

--- a/packages/system/vyuh_core/lib/plugin/plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin.dart
@@ -13,6 +13,13 @@ enum PluginType {
   ads,
 }
 
+/// A mixin to mark any plugin to be loaded before the Platform.
+///
+/// This mixin should be applied to plugins that need to be initialized
+/// before the main platform initialization. It ensures that the
+/// plugin is loaded at the correct time in the initialization sequence.
+mixin PreLoadedPlugin on Plugin {}
+
 abstract class Plugin {
   final String name;
   final String title;

--- a/packages/system/vyuh_core/lib/plugin/plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin.dart
@@ -3,7 +3,7 @@
 /// This mixin should be applied to plugins that need to be initialized
 /// before the main platform initialization. It ensures that the
 /// plugin is loaded at the correct time in the initialization sequence.
-mixin PreLoadedPlugin on Plugin {}
+mixin PreloadedPlugin on Plugin {}
 
 abstract class Plugin {
   final String name;

--- a/packages/system/vyuh_core/lib/plugin/plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin.dart
@@ -1,18 +1,3 @@
-enum PluginType {
-  content,
-  di,
-  analytics,
-  featureFlag,
-  navigation,
-  logger,
-  storage,
-  secureStorage,
-  network,
-  auth,
-  notifications,
-  ads,
-}
-
 /// A mixin to mark any plugin to be loaded before the Platform.
 ///
 /// This mixin should be applied to plugins that need to be initialized
@@ -23,9 +8,8 @@ mixin PreLoadedPlugin on Plugin {}
 abstract class Plugin {
   final String name;
   final String title;
-  final PluginType pluginType;
 
-  Plugin({required this.pluginType, required this.name, required this.title});
+  Plugin({required this.name, required this.title});
 
   Future<void> init();
   Future<void> dispose();

--- a/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
@@ -1,17 +1,5 @@
-import 'package:vyuh_core/plugin/content/noop_content_plugin.dart';
-import 'package:vyuh_core/plugin/di/di_plugin.dart';
-import 'package:vyuh_core/plugin/di/plugin_di_get_it.dart';
-import 'package:vyuh_core/plugin/plugin.dart';
-
-import 'analytics/analytics_plugin.dart';
-import 'analytics/noop_analytics_provider.dart';
-import 'auth/anonymous_auth_plugin.dart';
-import 'auth/auth_plugin.dart';
-import 'content/content_plugin.dart';
-import 'navigation/default_navigation_plugin.dart';
-import 'navigation/navigation.dart';
-import 'network/http_network_plugin.dart';
-import 'network/network_plugin.dart';
+import 'package:vyuh_core/plugin/auth/anonymous_auth_plugin.dart';
+import 'package:vyuh_core/vyuh_core.dart';
 
 final class PluginDescriptor {
   final Set<Plugin> _plugins = {};
@@ -19,23 +7,23 @@ final class PluginDescriptor {
   List<Plugin> get plugins => List.unmodifiable(_plugins);
 
   PluginDescriptor({
-    required final DIPlugin di,
-    required final ContentPlugin content,
-    required final AnalyticsPlugin analytics,
-    required final NetworkPlugin network,
-    required final AuthPlugin auth,
-    required final NavigationPlugin navigation,
+    final DIPlugin? di,
+    final ContentPlugin? content,
+    final AnalyticsPlugin? analytics,
+    final NetworkPlugin? network,
+    final AuthPlugin? auth,
+    final NavigationPlugin? navigation,
     final List<Plugin>? others,
   }) {
     _plugins.addAll([
-      di,
-      content,
-      analytics,
-      network,
-      auth,
-      navigation,
-      navigation,
+      di ?? defaultPlugins.get<DIPlugin>(),
+      content ?? defaultPlugins.get<ContentPlugin>(),
+      analytics ?? defaultPlugins.get<AnalyticsPlugin>(),
+      network ?? defaultPlugins.get<NetworkPlugin>(),
+      auth ?? defaultPlugins.get<AuthPlugin>(),
+      navigation ?? defaultPlugins.get<NavigationPlugin>(),
     ]);
+
     _plugins.addAll(others ?? []);
   }
 
@@ -47,4 +35,8 @@ final class PluginDescriptor {
     auth: UnknownAuthPlugin(),
     navigation: DefaultNavigationPlugin(),
   );
+
+  Plugin get<T>() {
+    return _plugins.firstWhere((element) => element is T);
+  }
 }

--- a/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
@@ -13,7 +13,7 @@ import 'navigation/navigation.dart';
 import 'network/http_network_plugin.dart';
 import 'network/network_plugin.dart';
 
-class PluginDescriptor {
+final class PluginDescriptor {
   final Set<Plugin> _plugins = {};
 
   List<Plugin> get plugins => List.unmodifiable(_plugins);
@@ -27,22 +27,24 @@ class PluginDescriptor {
     required final NavigationPlugin navigation,
     final List<Plugin>? others,
   }) {
-    _plugins.add(di);
-    _plugins.add(content);
-    _plugins.add(analytics);
-    _plugins.add(network);
-    _plugins.add(auth);
-    _plugins.add(navigation);
-    _plugins.add(navigation);
+    _plugins.addAll([
+      di,
+      content,
+      analytics,
+      network,
+      auth,
+      navigation,
+      navigation,
+    ]);
     _plugins.addAll(others ?? []);
   }
-}
 
-PluginDescriptor defaultPlugins() => PluginDescriptor(
-      di: GetItDIPlugin(),
-      content: NoOpContentPlugin(),
-      analytics: AnalyticsPlugin(providers: [NoOpAnalyticsProvider()]),
-      network: HttpNetworkPlugin(),
-      auth: UnknownAuthPlugin(),
-      navigation: DefaultNavigationPlugin(),
-    );
+  static final defaultPlugins = PluginDescriptor(
+    di: GetItDIPlugin(),
+    content: NoOpContentPlugin(),
+    analytics: AnalyticsPlugin(providers: [NoOpAnalyticsProvider()]),
+    network: HttpNetworkPlugin(),
+    auth: UnknownAuthPlugin(),
+    navigation: DefaultNavigationPlugin(),
+  );
+}

--- a/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
+++ b/packages/system/vyuh_core/lib/plugin/plugin_descriptor.dart
@@ -1,0 +1,48 @@
+import 'package:vyuh_core/plugin/content/noop_content_plugin.dart';
+import 'package:vyuh_core/plugin/di/di_plugin.dart';
+import 'package:vyuh_core/plugin/di/plugin_di_get_it.dart';
+import 'package:vyuh_core/plugin/plugin.dart';
+
+import 'analytics/analytics_plugin.dart';
+import 'analytics/noop_analytics_provider.dart';
+import 'auth/anonymous_auth_plugin.dart';
+import 'auth/auth_plugin.dart';
+import 'content/content_plugin.dart';
+import 'navigation/default_navigation_plugin.dart';
+import 'navigation/navigation.dart';
+import 'network/http_network_plugin.dart';
+import 'network/network_plugin.dart';
+
+class PluginDescriptor {
+  final Set<Plugin> _plugins = {};
+
+  List<Plugin> get plugins => List.unmodifiable(_plugins);
+
+  PluginDescriptor({
+    required final DIPlugin di,
+    required final ContentPlugin content,
+    required final AnalyticsPlugin analytics,
+    required final NetworkPlugin network,
+    required final AuthPlugin auth,
+    required final NavigationPlugin navigation,
+    final List<Plugin>? others,
+  }) {
+    _plugins.add(di);
+    _plugins.add(content);
+    _plugins.add(analytics);
+    _plugins.add(network);
+    _plugins.add(auth);
+    _plugins.add(navigation);
+    _plugins.add(navigation);
+    _plugins.addAll(others ?? []);
+  }
+}
+
+PluginDescriptor defaultPlugins() => PluginDescriptor(
+      di: GetItDIPlugin(),
+      content: NoOpContentPlugin(),
+      analytics: AnalyticsPlugin(providers: [NoOpAnalyticsProvider()]),
+      network: HttpNetworkPlugin(),
+      auth: UnknownAuthPlugin(),
+      navigation: DefaultNavigationPlugin(),
+    );

--- a/packages/system/vyuh_core/lib/plugin/storage_plugin.dart
+++ b/packages/system/vyuh_core/lib/plugin/storage_plugin.dart
@@ -2,7 +2,7 @@ import 'package:vyuh_core/vyuh_core.dart';
 
 abstract class StoragePlugin extends Plugin {
   StoragePlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.storage);
+      : super();
 
   Future<dynamic> read(String key);
   Future<dynamic> write(String key, dynamic value);
@@ -12,7 +12,7 @@ abstract class StoragePlugin extends Plugin {
 
 abstract class SecureStoragePlugin extends Plugin {
   SecureStoragePlugin({required super.name, required super.title})
-      : super(pluginType: PluginType.secureStorage);
+      : super();
 
   Future<dynamic> read(String key);
   Future<dynamic> write(String key, dynamic value);

--- a/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
@@ -81,8 +81,10 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
 
   @override
   Future<void> run() async {
-    for (final plugin in VyuhPlatform.preloadedPlugins) {
-      await _pluginMap[plugin]?.init();
+    final plugins = _pluginMap.values.whereType<vt.PreLoadedPlugin>();
+
+    for (final plugin in plugins) {
+      await plugin.init();
     }
 
     _userInitialLocation = PlatformDispatcher.instance.defaultRouteName;

--- a/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
@@ -1,9 +1,9 @@
 part of '../run_app.dart';
 
-class _CacheableLookupPluginList {
+class _PluginInstanceCache {
   final Set<Plugin> _plugins = {};
 
-  _CacheableLookupPluginList();
+  _PluginInstanceCache();
 
   final Map<Type, Plugin?> _pluginsMap = {};
 
@@ -32,7 +32,7 @@ class _CacheableLookupPluginList {
 }
 
 final class _DefaultVyuhPlatform extends VyuhPlatform {
-  final _CacheableLookupPluginList _plugins = _CacheableLookupPluginList();
+  final _PluginInstanceCache _plugins = _PluginInstanceCache();
 
   final Map<Type, ExtensionBuilder> _featureExtensionBuilderMap = {};
 
@@ -56,7 +56,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
   List<FeatureDescriptor> _features = [];
 
   @override
-  List<vt.FeatureDescriptor> get features => _features;
+  List<vc.FeatureDescriptor> get features => _features;
 
   final Map<String, Future<void>> _readyFeatures = {};
 
@@ -94,7 +94,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
 
   @override
   Future<void> run() async {
-    final preLoadedPlugins = plugins.whereType<vt.PreLoadedPlugin>();
+    final preLoadedPlugins = plugins.whereType<vc.PreloadedPlugin>();
 
     for (final plugin in preLoadedPlugins) {
       await plugin.init();
@@ -106,7 +106,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
   }
 
   @override
-  Future<void> initPlugins(vt.AnalyticsTrace parentTrace) =>
+  Future<void> initPlugins(vc.AnalyticsTrace parentTrace) =>
       analytics.runWithTrace(
           name: 'Plugins',
           operation: 'Init',
@@ -130,7 +130,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
           });
 
   @override
-  Future<void> initFeatures(vt.AnalyticsTrace parentTrace) async {
+  Future<void> initFeatures(vc.AnalyticsTrace parentTrace) async {
     // Run a cleanup first
     final disposeFns =
         _features.where((e) => e.dispose != null).map((e) => e.dispose!());
@@ -173,12 +173,12 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
     );
   }
 
-  void _initContent(List<vt.FeatureDescriptor> featureList) {
+  void _initContent(List<vc.FeatureDescriptor> featureList) {
     content.setup(featureList);
   }
 
   Future<List<g.RouteBase>> _initFeature(
-      FeatureDescriptor feature, vt.AnalyticsTrace? parentTrace) async {
+      FeatureDescriptor feature, vc.AnalyticsTrace? parentTrace) async {
     await feature.init?.call();
 
     if (feature.routes == null) {
@@ -208,7 +208,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
   void _initFeatureExtensions(List<FeatureDescriptor> featureList) {
     // Run a cleanup first
     _features
-        .expand((e) => e.extensionBuilders ?? <vt.ExtensionBuilder>[])
+        .expand((e) => e.extensionBuilders ?? <vc.ExtensionBuilder>[])
         .forEach((e) => e.dispose());
 
     final builders = featureList
@@ -240,7 +240,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
   }
 
   @override
-  T? getPlugin<T extends vt.Plugin>() => _plugins.getPlugin<T>();
+  T? getPlugin<T extends vc.Plugin>() => _plugins.getPlugin<T>();
 }
 
 final class RoutingConfigNotifier extends ValueNotifier<g.RoutingConfig> {

--- a/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
@@ -19,12 +19,12 @@ class _CacheableLookupPluginList {
     return plugin as T?;
   }
 
+  /// Add Items to List.
+  ///
+  /// NOTE: This remove the Lookup cache.
   void addAll(Iterable<Plugin> plugins) {
     _plugins.addAll(plugins);
-  }
-
-  void add(vt.Plugin plugin) {
-    _plugins.add(plugin);
+    _pluginsMap.clear();
   }
 
   // Get the list

--- a/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/default_platform.dart
@@ -74,11 +74,11 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
 
   _DefaultVyuhPlatform({
     required this.featuresBuilder,
-    required List<Plugin> plugins,
+    required PluginDescriptor pluginDescriptor,
     required this.widgetBuilder,
     this.initialLocation,
   }) {
-    _plugins.addAll(_ensureRequiredPlugins(plugins));
+    _plugins.addAll(pluginDescriptor.plugins);
 
     _tracker = _PlatformInitTracker(this);
 
@@ -90,32 +90,6 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
         _rootNavigatorKey = GlobalKey<NavigatorState>();
       }
     });
-  }
-
-  static List<Plugin> _ensureRequiredPlugins(List<Plugin> plugins) {
-    // Ensure there is only one plugin for a PluginType
-    final pluginTypes = plugins.groupListsBy((element) => element.pluginType);
-    for (final entry in pluginTypes.entries) {
-      assert(entry.value.length == 1,
-          'There can be only one plugin for a pluginType. We found ${entry.value.length} for ${entry.key}');
-    }
-
-    final allPlugins = [...plugins];
-    for (final type in VyuhPlatform.requiredPlugins) {
-      // Put a default plugin instance when a required plugin is not explicitly given
-      if (!allPlugins.any((element) => element.pluginType == type)) {
-        final instance = type.defaultInstance();
-
-        assert(instance != null,
-            'The default instance for the required plugin: $type has not been provided.');
-
-        if (instance != null) {
-          allPlugins.add(instance);
-        }
-      }
-    }
-
-    return allPlugins;
   }
 
   @override
@@ -266,7 +240,7 @@ final class _DefaultVyuhPlatform extends VyuhPlatform {
   }
 
   @override
-  T? getPlugin<T extends vt.Plugin>(PluginType type) => _plugins.getPlugin<T>();
+  T? getPlugin<T extends vt.Plugin>() => _plugins.getPlugin<T>();
 }
 
 final class RoutingConfigNotifier extends ValueNotifier<g.RoutingConfig> {
@@ -276,17 +250,4 @@ final class RoutingConfigNotifier extends ValueNotifier<g.RoutingConfig> {
   void setRoutes(List<g.RouteBase> routes) {
     value = g.RoutingConfig(routes: routes);
   }
-}
-
-extension on PluginType {
-  Plugin? defaultInstance() => switch (this) {
-        PluginType.analytics =>
-          AnalyticsPlugin(providers: [NoOpAnalyticsProvider()]),
-        PluginType.content => NoOpContentPlugin(),
-        PluginType.di => GetItDIPlugin(),
-        PluginType.network => HttpNetworkPlugin(),
-        PluginType.auth => UnknownAuthPlugin(),
-        PluginType.navigation => DefaultNavigationPlugin(),
-        _ => null
-      };
 }

--- a/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
@@ -34,14 +34,6 @@ abstract class VyuhPlatform {
   /// The list of features that are available to the platform.
   List<FeatureDescriptor> get features;
 
-  /// The list of plugins that are preloaded and are available before the platform is initialized.
-  @protected
-  static const preloadedPlugins = [
-    PluginType.analytics,
-    PluginType.network,
-    PluginType.di,
-  ];
-
   /// The list of plugins that are required for the platform to function correctly.
   @protected
   static const requiredPlugins = [

--- a/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
@@ -14,13 +14,13 @@ typedef FeaturesBuilder = FutureOr<List<FeatureDescriptor>> Function();
 /// platform and managing the lifecycle of the platform.
 abstract class VyuhPlatform {
   /// The builder function that creates a set of features.
-  final FeaturesBuilder featuresBuilder;
+  FeaturesBuilder get featuresBuilder;
 
   /// The list of plugins that are available to the platform.
-  final List<Plugin> plugins;
+  List<Plugin> get plugins;
 
   /// The builder function that creates the various widgets for the platform.
-  final PlatformWidgetBuilder widgetBuilder;
+  PlatformWidgetBuilder get widgetBuilder;
 
   /// The key for the root navigator. This is plugged into the router plugin.
   GlobalKey<NavigatorState> get rootNavigatorKey;
@@ -46,13 +46,6 @@ abstract class VyuhPlatform {
     // PluginType.storage,
   ];
 
-  /// Creates a new instance of the platform.
-  VyuhPlatform({
-    required this.featuresBuilder,
-    required this.plugins,
-    required this.widgetBuilder,
-  });
-
   /// Initializes the platform. This is called internally by the platform and should not be invoked directly.
   FutureOr<void> run();
 
@@ -63,48 +56,35 @@ abstract class VyuhPlatform {
   Future<void> initFeatures(AnalyticsTrace parentTrace);
 
   /// Used to get the specific plugin instance for the given type.
-  Plugin? getPlugin(PluginType type);
+  T? getPlugin<T extends Plugin>(PluginType type);
 }
 
 /// An extension to access the named plugins.
 extension NamedPlugins on VyuhPlatform {
   /// The content plugin.
-  ContentPlugin get content => ensurePlugin<ContentPlugin>(PluginType.content);
+  ContentPlugin get content => getPlugin<ContentPlugin>(PluginType.content)!;
 
   /// The dependency injection plugin.
-  DIPlugin get di => ensurePlugin<DIPlugin>(PluginType.di);
+  DIPlugin get di => getPlugin<DIPlugin>(PluginType.di)!;
 
   /// The logger plugin.
-  LoggerPlugin? get log =>
-      ensurePlugin<LoggerPlugin?>(PluginType.logger, mustExist: false);
+  LoggerPlugin? get log => getPlugin<LoggerPlugin>(PluginType.logger);
 
   /// The analytics plugin.
   AnalyticsPlugin get analytics =>
-      ensurePlugin<AnalyticsPlugin>(PluginType.analytics);
+      getPlugin<AnalyticsPlugin>(PluginType.analytics)!;
 
   /// The network plugin.
-  NetworkPlugin get network => ensurePlugin<NetworkPlugin>(PluginType.network);
+  NetworkPlugin get network => getPlugin<NetworkPlugin>(PluginType.network)!;
 
   /// The authentication plugin.
-  AuthPlugin get auth => ensurePlugin<AuthPlugin>(PluginType.auth);
+  AuthPlugin get auth => getPlugin<AuthPlugin>(PluginType.auth)!;
 
   /// The navigation plugin.
   NavigationPlugin get router =>
-      ensurePlugin<NavigationPlugin>(PluginType.navigation);
+      getPlugin<NavigationPlugin>(PluginType.navigation)!;
 
   /// The feature flag plugin.
   FeatureFlagPlugin? get featureFlag =>
-      ensurePlugin<FeatureFlagPlugin?>(PluginType.featureFlag,
-          mustExist: false);
-
-  /// A safe way to get the plugin instance.
-  T ensurePlugin<T>(PluginType type, {bool mustExist = true}) {
-    final plugin = getPlugin(type) as T;
-
-    if (mustExist) {
-      assert(plugin != null, '$T is not available in your plugins');
-    }
-
-    return plugin;
-  }
+      getPlugin<FeatureFlagPlugin>(PluginType.featureFlag);
 }

--- a/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
+++ b/packages/system/vyuh_core/lib/runtime/platform/vyuh_platform.dart
@@ -34,18 +34,6 @@ abstract class VyuhPlatform {
   /// The list of features that are available to the platform.
   List<FeatureDescriptor> get features;
 
-  /// The list of plugins that are required for the platform to function correctly.
-  @protected
-  static const requiredPlugins = [
-    PluginType.content,
-    PluginType.di,
-    PluginType.analytics,
-    PluginType.network,
-    PluginType.auth,
-    PluginType.navigation,
-    // PluginType.storage,
-  ];
-
   /// Initializes the platform. This is called internally by the platform and should not be invoked directly.
   FutureOr<void> run();
 
@@ -56,35 +44,35 @@ abstract class VyuhPlatform {
   Future<void> initFeatures(AnalyticsTrace parentTrace);
 
   /// Used to get the specific plugin instance for the given type.
-  T? getPlugin<T extends Plugin>(PluginType type);
+  T? getPlugin<T extends Plugin>();
 }
 
 /// An extension to access the named plugins.
 extension NamedPlugins on VyuhPlatform {
   /// The content plugin.
-  ContentPlugin get content => getPlugin<ContentPlugin>(PluginType.content)!;
+  ContentPlugin get content => getPlugin<ContentPlugin>()!;
 
   /// The dependency injection plugin.
-  DIPlugin get di => getPlugin<DIPlugin>(PluginType.di)!;
+  DIPlugin get di => getPlugin<DIPlugin>()!;
 
   /// The logger plugin.
-  LoggerPlugin? get log => getPlugin<LoggerPlugin>(PluginType.logger);
+  LoggerPlugin? get log => getPlugin<LoggerPlugin>();
 
   /// The analytics plugin.
   AnalyticsPlugin get analytics =>
-      getPlugin<AnalyticsPlugin>(PluginType.analytics)!;
+      getPlugin<AnalyticsPlugin>()!;
 
   /// The network plugin.
-  NetworkPlugin get network => getPlugin<NetworkPlugin>(PluginType.network)!;
+  NetworkPlugin get network => getPlugin<NetworkPlugin>()!;
 
   /// The authentication plugin.
-  AuthPlugin get auth => getPlugin<AuthPlugin>(PluginType.auth)!;
+  AuthPlugin get auth => getPlugin<AuthPlugin>()!;
 
   /// The navigation plugin.
   NavigationPlugin get router =>
-      getPlugin<NavigationPlugin>(PluginType.navigation)!;
+      getPlugin<NavigationPlugin>()!;
 
   /// The feature flag plugin.
   FeatureFlagPlugin? get featureFlag =>
-      getPlugin<FeatureFlagPlugin>(PluginType.featureFlag);
+      getPlugin<FeatureFlagPlugin>();
 }

--- a/packages/system/vyuh_core/lib/runtime/run_app.dart
+++ b/packages/system/vyuh_core/lib/runtime/run_app.dart
@@ -7,12 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:go_router/go_router.dart' as g;
 import 'package:mobx/mobx.dart';
-import 'package:vyuh_core/plugin/auth/anonymous_auth_plugin.dart';
+import 'package:vyuh_core/plugin/plugin_descriptor.dart';
 import 'package:vyuh_core/vyuh_core.dart' as vt;
 import 'package:vyuh_core/vyuh_core.dart';
 
 part 'platform/default_platform.dart';
+
 part 'platform/framework_init_view.dart';
+
 part 'platform/platform_init_tracker.dart';
 
 /// The main entry point to kick off the Vyuh Application.
@@ -20,7 +22,7 @@ part 'platform/platform_init_tracker.dart';
 /// It initializes the Vyuh Platform and runs the application with given features and plugins.
 void runApp({
   required FeaturesBuilder features,
-  List<Plugin>? plugins,
+  PluginDescriptor? plugins,
   PlatformWidgetBuilder? platformWidgetBuilder,
   String? initialLocation,
 }) async {
@@ -30,7 +32,7 @@ void runApp({
 
   vyuh = _DefaultVyuhPlatform(
     featuresBuilder: features,
-    plugins: plugins ?? [],
+    pluginDescriptor: plugins ?? defaultPlugins(),
     widgetBuilder: widgetBuilder,
     initialLocation: initialLocation,
   );

--- a/packages/system/vyuh_core/lib/runtime/run_app.dart
+++ b/packages/system/vyuh_core/lib/runtime/run_app.dart
@@ -8,13 +8,11 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:go_router/go_router.dart' as g;
 import 'package:mobx/mobx.dart';
 import 'package:vyuh_core/plugin/plugin_descriptor.dart';
-import 'package:vyuh_core/vyuh_core.dart' as vt;
+import 'package:vyuh_core/vyuh_core.dart' as vc;
 import 'package:vyuh_core/vyuh_core.dart';
 
 part 'platform/default_platform.dart';
-
 part 'platform/framework_init_view.dart';
-
 part 'platform/platform_init_tracker.dart';
 
 /// The main entry point to kick off the Vyuh Application.
@@ -32,7 +30,7 @@ void runApp({
 
   vyuh = _DefaultVyuhPlatform(
     featuresBuilder: features,
-    pluginDescriptor: plugins ?? defaultPlugins(),
+    pluginDescriptor: plugins ?? PluginDescriptor.defaultPlugins,
     widgetBuilder: widgetBuilder,
     initialLocation: initialLocation,
   );

--- a/packages/system/vyuh_feature_developer/lib/plugin_detail.dart
+++ b/packages/system/vyuh_feature_developer/lib/plugin_detail.dart
@@ -1,43 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:vyuh_core/plugin/storage_plugin.dart';
 import 'package:vyuh_core/vyuh_core.dart';
 import 'package:vyuh_feature_developer/components/standard_plugin_view.dart';
 
 extension WidgetBuilder on Plugin {
   Widget build(BuildContext context) {
-    switch (pluginType) {
-      case PluginType.analytics || PluginType.content:
+    switch (this) {
+      case AnalyticsPlugin() || ContentPlugin():
         return _PluginWithDetailsItem(plugin: this);
       default:
         return ListTile(
-          leading: Icon(pluginType.icon),
+          leading: Icon(icon),
           title: StandardPluginItem(plugin: this),
         );
     }
   }
-}
 
-extension on PluginType {
   IconData get icon {
     switch (this) {
-      case PluginType.analytics:
+      case AnalyticsPlugin():
         return Icons.show_chart;
-      case PluginType.content:
+      case ContentPlugin():
         return Icons.category;
-      case PluginType.logger:
+      case LoggerPlugin():
         return Icons.line_style;
-      case PluginType.di:
+      case DIPlugin():
         return Icons.insert_link;
-      case PluginType.network:
+      case NetworkPlugin():
         return Icons.network_check;
-      case PluginType.storage:
+      case StoragePlugin():
         return Icons.data_object;
-      case PluginType.secureStorage:
+      case SecureStoragePlugin():
         return Icons.dataset;
-      case PluginType.featureFlag:
+      case FeatureFlagPlugin():
         return Icons.flag;
-      case PluginType.auth:
+      case AuthPlugin():
         return Icons.account_circle;
-      case PluginType.navigation:
+      case NavigationPlugin():
         return Icons.navigation_outlined;
       default:
         return Icons.extension;
@@ -53,9 +52,9 @@ class _PluginWithDetailsItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: Icon(plugin.pluginType.icon),
+      leading: Icon(plugin.icon),
       onTap: () {
-        vyuh.router.push('/developer/plugins/${plugin.pluginType.name}');
+        vyuh.router.push('/developer/plugins/${plugin.name}');
       },
       title: StandardPluginItem(plugin: plugin),
       trailing: const Icon(Icons.chevron_right),

--- a/packages/system/vyuh_feature_developer/lib/vyuh_feature_developer.dart
+++ b/packages/system/vyuh_feature_developer/lib/vyuh_feature_developer.dart
@@ -39,10 +39,10 @@ final feature = FeatureDescriptor(
           GoRoute(
             path: 'plugins/:name',
             builder: (context, state) {
-              final pluginType = PluginType.values.firstWhere(
+              final plugin = vyuh.plugins.firstWhere(
                   (element) => element.name == state.pathParameters['name']);
 
-              return pluginType.detailsView(context);
+              return plugin.detailsView(context);
             },
           ),
           GoRoute(
@@ -54,17 +54,16 @@ final feature = FeatureDescriptor(
   ],
 );
 
-extension on PluginType {
+extension on Plugin {
   Widget detailsView(BuildContext context) {
-    final plugin =
-        vyuh.plugins.firstWhere((element) => element.pluginType == this);
+    final plugin = vyuh.plugins.firstWhere((element) => element == this);
 
     switch (this) {
-      case PluginType.analytics:
+      case AnalyticsPlugin():
         return AnalyticsPluginDetail(
           plugin: plugin as AnalyticsPlugin,
         );
-      case PluginType.content:
+      case ContentPlugin():
         return ContentPluginDetailsView(
           plugin: plugin as ContentPlugin,
         );


### PR DESCRIPTION
This will help us to mark any plugin to be preloaded without any Change to Vyuh Core.

Revamped the handling of preloaded plugins by introducing the PreLoadedPlugin mixin. Applied this mixin to DIPlugin, AnalyticsPlugin, and NetworkPlugin to ensure they are initialized before the platform. Removed the static list of preloadedPlugins from VyuhPlatform.